### PR TITLE
Implement feature for getting quotes from an external process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile
 #
 # qotd - A simple QOTD daemon.
-# Copyright (c) 2015-2016 Emmie Smith
+# Copyright (c) 2015-2024 Emmie Smith
 #
 # qotd is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/man/Makefile
+++ b/man/Makefile
@@ -1,7 +1,7 @@
 # Makefile
 #
 # qotd - A simple QOTD daemon.
-# Copyright (c) 2015-2016 Emmie Smith
+# Copyright (c) 2015-2024 Emmie Smith
 #
 # qotd is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/man/qotd.conf.5
+++ b/man/qotd.conf.5
@@ -1,4 +1,4 @@
-.TH QOTD.CONF 5 2016-01-29 "qotd 0.12.0" "System Manager's Manual"
+.TH QOTD.CONF 5 2024-01-29 "qotd 0.12.0" "System Manager's Manual"
 .\" %%%LICENSE_START(GPLv2+_DOC_FULL)
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as

--- a/man/qotdd.8
+++ b/man/qotdd.8
@@ -1,4 +1,4 @@
-.TH QOTDD 8 2016-01-29 "qotd 0.12.0" "System Manager's Manual"
+.TH QOTDD 8 2024-01-29 "qotd 0.12.0" "System Manager's Manual"
 .\" %%%LICENSE_START(GPLv2+_DOC_FULL)
 .\" This is free documentation; you can redistribute it and/or
 .\" modify it under the terms of the GNU General Public License as

--- a/misc/local-bg.conf
+++ b/misc/local-bg.conf
@@ -18,4 +18,3 @@ PadQuotes yes
 
 DailyQuotes yes
 AllowBigQuotes no
-

--- a/misc/local-file.conf
+++ b/misc/local-file.conf
@@ -17,4 +17,3 @@ PadQuotes yes
 
 DailyQuotes yes
 AllowBigQuotes no
-

--- a/misc/local.conf
+++ b/misc/local.conf
@@ -17,4 +17,3 @@ PadQuotes yes
 
 DailyQuotes yes
 AllowBigQuotes no
-

--- a/misc/qotd.conf
+++ b/misc/qotd.conf
@@ -66,4 +66,3 @@ DailyQuotes yes
 # option is set to 'yes', this limit is ignored. Otherwise, quotes are
 # automatically truncated to meet the byte limit.
 AllowBigQuotes no
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 # Makefile
 #
 # qotd - A simple QOTD daemon.
-# Copyright (c) 2015-2016 Emmie Smith
+# Copyright (c) 2015-2024 Emmie Smith
 #
 # qotd is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -2,7 +2,7 @@
  * arguments.c
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/arguments.c
+++ b/src/arguments.c
@@ -189,8 +189,9 @@ static void parse_short_options(const char *argument,
 {
 	size_t i;
 
-	if (DEBUG)
+	if (DEBUG) {
 		journal("Parsing options in \"-%s\":\n", argument);
+	}
 
 	for (i = 0; argument[i]; i++) {
 #if DEBUG
@@ -429,8 +430,9 @@ void parse_args(struct options *const opt,
 	opt->strict = flags.strict;
 
 	if (flags.conf_file) {
-		if (flags.conf_file[0] != '/')
+		if (flags.conf_file[0] != '/') {
 			opt->chdir_root = 0;
+		}
 		parse_config(opt, flags.conf_file);
 	}
 	if (flags.pid_file) {

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -2,7 +2,7 @@
  * arguments.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/config.c
+++ b/src/config.c
@@ -2,7 +2,7 @@
  * configuration.c
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/config.c
+++ b/src/config.c
@@ -57,8 +57,9 @@ static int caseless_eq(const struct string *x,
 	size_t i;
 	char c1, c2;
 
-	if (x->length != y_len)
+	if (x->length != y_len) {
 		return 0;
+	}
 	for (i = 0; i < y_len; i++) {
 		c1 = tolower(x->ptr[i]);
 		c2 = tolower(y[i]);
@@ -72,8 +73,9 @@ static void print_str(FILE *out, const struct string *s)
 {
 	size_t i;
 
-	for (i = 0; i < s->length; i++)
+	for (i = 0; i < s->length; i++) {
 		putc(s->ptr[i], out);
+	}
 	putc('\n', out);
 }
 
@@ -82,8 +84,9 @@ static char *dup_str(const struct string *s)
 	char *buf;
 
 	buf = malloc(s->length + 1);
-	if (unlikely(!buf))
+	if (unlikely(!buf)) {
 		return NULL;
+	}
 
 	memcpy(buf, s->ptr, s->length);
 	buf[s->length] = '\0';
@@ -193,12 +196,13 @@ static int str_to_bool(const struct string *s,
 {
 	if (caseless_eq(s, "yes", 3) ||
 	    caseless_eq(s, "true", 4) ||
-	    caseless_eq(s, "1", 1))
+	    caseless_eq(s, "1", 1)) {
 		return 1;
-	else if (caseless_eq(s, "no", 2) ||
+	} else if (caseless_eq(s, "no", 2) ||
 		 caseless_eq(s, "false", 5) ||
-		 caseless_eq(s, "0", 1))
+		 caseless_eq(s, "0", 1)) {
 		return 0;
+	}
 
 	fprintf(stderr, "%s:%u: not a boolean value: ",
 		filename, lineno);
@@ -236,8 +240,9 @@ static int process_line(struct options *opt,
 	struct string key, val;
 	int n;
 
-	if (read_kv(conf_file, lineno, line, &key, &val))
+	if (read_kv(conf_file, lineno, line, &key, &val)) {
 		return key.ptr != NULL;
+	}
 
 	if (DEBUG) {
 		fputs("\tKey: ", stdout);
@@ -249,8 +254,9 @@ static int process_line(struct options *opt,
 	/* Check each possible option */
 	if (caseless_eq(&key, "Daemonize", 9)) {
 		n = str_to_bool(&val, conf_file, lineno);
-		if (unlikely(NOT_BOOL(n)))
+		if (unlikely(NOT_BOOL(n))) {
 			return -1;
+		}
 		opt->daemonize = n;
 	} else if (caseless_eq(&key, "TransportProtocol", 17)) {
 		if (caseless_eq(&val, "tcp", 3)) {
@@ -278,18 +284,21 @@ static int process_line(struct options *opt,
 		}
 	} else if (caseless_eq(&key, "Port", 4)) {
 		n = get_port(&val, conf_file, lineno);
-		if (unlikely(n < 0))
+		if (unlikely(n < 0)) {
 			return -1;
+		}
 		opt->port = n;
 	} else if (caseless_eq(&key, "StrictChecking", 14)) {
 		n = str_to_bool(&val, conf_file, lineno);
-		if (unlikely(NOT_BOOL(n)))
+		if (unlikely(NOT_BOOL(n))) {
 			return -1;
+		}
 		opt->strict = n;
 	} else if (caseless_eq(&key, "DropPrivileges", 14)) {
 		n = str_to_bool(&val, conf_file, lineno);
-		if (unlikely(NOT_BOOL(n)))
+		if (unlikely(NOT_BOOL(n))) {
 			return -1;
+		}
 		opt->drop_privileges = n;
 	} else if (caseless_eq(&key, "PidFile", 7)) {
 		if (caseless_eq(&val, "none", 4)) {
@@ -304,8 +313,9 @@ static int process_line(struct options *opt,
 		}
 	} else if (caseless_eq(&key, "RequirePidFile", 14)) {
 		n = str_to_bool(&val, conf_file, lineno);
-		if (unlikely(NOT_BOOL(n)))
+		if (unlikely(NOT_BOOL(n))) {
 			return -1;
+		}
 		opt->require_pidfile = n;
 	} else if (caseless_eq(&key, "JournalFile", 11)) {
 		if (caseless_eq(&val, "-", 1)) {
@@ -338,18 +348,21 @@ static int process_line(struct options *opt,
 		}
 	} else if (caseless_eq(&key, "PadQuotes", 9)) {
 		n = str_to_bool(&val, conf_file, lineno);
-		if (unlikely(NOT_BOOL(n)))
+		if (unlikely(NOT_BOOL(n))) {
 			return -1;
+		}
 		opt->pad_quotes = n;
 	} else if (caseless_eq(&key, "DailyQuotes", 11)) {
 		n = str_to_bool(&val, conf_file, lineno);
-		if (unlikely(NOT_BOOL(n)))
+		if (unlikely(NOT_BOOL(n))) {
 			return -1;
+		}
 		opt->is_daily = n;
 	} else if (caseless_eq(&key, "AllowBigQuotes", 14)) {
 		n = str_to_bool(&val, conf_file, lineno);
-		if (unlikely(NOT_BOOL(n)))
+		if (unlikely(NOT_BOOL(n))) {
 			return -1;
+		}
 		opt->allow_big = n;
 	} else {
 		fprintf(stderr, "%s:%u: unknown config option: ",
@@ -369,8 +382,9 @@ void parse_config(struct options *opt, const char *conf_file)
 	/* Journal hasn't been opened yet */
 	printf("Reading configuration file at \"%s\"...\n", conf_file);
 
-	if (opt->strict)
+	if (opt->strict) {
 		security_conf_file_check(conf_file);
+	}
 
 	fh = fopen(conf_file, "r");
 	if (!fh) {
@@ -385,8 +399,9 @@ void parse_config(struct options *opt, const char *conf_file)
 	lineno = 1;
 	errors = 0;
 	while (!read_line(fh, conf_file, &lineno, &line)) {
-		if (process_line(opt, conf_file, lineno, &line))
+		if (process_line(opt, conf_file, lineno, &line)) {
 			errors++;
+		}
 		lineno++;
 	}
 	fclose(fh);

--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,7 @@
  * config.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/core.c
+++ b/src/core.c
@@ -2,7 +2,7 @@
  * core.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/core.h
+++ b/src/core.h
@@ -2,7 +2,7 @@
  * core.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/core.h
+++ b/src/core.h
@@ -125,6 +125,10 @@
 # define NORETURN
 #endif /* __GNUC__ || __clang__ */
 
+/* Constants */
+
+#define QUOTE_SIZE				512  /* Set by RFC 865 */
+
 /* Functions */
 
 void print_version(void);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -32,7 +32,7 @@
 #include "journal.h"
 #include "network.h"
 #include "pid_file.h"
-#include "quotes.h"
+#include "quotes_file.h"
 #include "security.h"
 #include "signal_hndl.h"
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -2,7 +2,7 @@
  * daemon.c
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -70,8 +70,9 @@ static int main_loop(void)
 		cleanup(EXIT_INTERNAL, 1);
 	}
 
-	if (opt.drop_privileges)
+	if (opt.drop_privileges) {
 		drop_privileges();
+	}
 
 	switch (opt.tproto) {
 	case PROTOCOL_TCP:
@@ -88,8 +89,9 @@ static int main_loop(void)
 		return -1;
 	}
 
-	for (;;)
+	for (;;) {
 		accept_connection();
+	}
 }
 
 static int daemonize(void)
@@ -121,24 +123,27 @@ static int daemonize(void)
 
 int main(const int argc, const char *const argv[])
 {
-	if (DEBUG)
+	if (DEBUG) {
 		printf("(Running in debug mode)\n");
+	}
 
 	signal_handler_init();
 	load_config(argc, argv);
 	open_journal(opt.journal_file);
 
 	/* Check security settings */
-	if (opt.strict)
+	if (opt.strict) {
 		security_options_check(&opt);
+	}
 
 	return opt.daemonize ? daemonize() : main_loop();
 }
 
 void cleanup(int ret, int quiet)
 {
-	if (!quiet)
+	if (!quiet) {
 		journal("Quitting with exit code %d.\n", ret);
+	}
 
 	pidfile_remove(&opt);
 	destroy_quote_buffers();

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -34,7 +34,7 @@
 #include "pid_file.h"
 #include "quotes_file.h"
 #include "security.h"
-#include "signal_hndl.h"
+#include "signal_handler.h"
 
 static struct options opt;
 
@@ -124,7 +124,7 @@ int main(const int argc, const char *const argv[])
 	if (DEBUG)
 		printf("(Running in debug mode)\n");
 
-	signal_hndl_init();
+	signal_handler_init();
 	load_config(argc, argv);
 	open_journal(opt.journal_file);
 

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -2,7 +2,7 @@
  * daemon.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/journal.c
+++ b/src/journal.c
@@ -51,8 +51,9 @@ void open_journal(const char *const path)
 		return;
 	}
 
-	if (DEBUG)
+	if (DEBUG) {
 		printf("Setting journal to be \"%s\".\n", path);
+	}
 
 	journal_fh = fopen(path, "w");
 	if (!journal_fh) {
@@ -84,8 +85,9 @@ int journal(const char *const format, ...)
 	va_list args;
 	int ret;
 
-	if (!journal_fh)
+	if (!journal_fh) {
 		return 0;
+	}
 
 	va_start(args, format);
 	ret = vfprintf(journal_fh, format, args);

--- a/src/journal.c
+++ b/src/journal.c
@@ -2,7 +2,7 @@
  * journal.c
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/journal.h
+++ b/src/journal.h
@@ -2,7 +2,7 @@
  * journal.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/network.c
+++ b/src/network.c
@@ -2,7 +2,7 @@
  * network.c
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/network.c
+++ b/src/network.c
@@ -291,7 +291,7 @@ void tcp_accept_connection(void)
 	log_client(&cli_addr);
 #endif /* DEBUG */
 
-	if (get_quote_of_the_day(&buffer, &length)) {
+	if (get_quote_from_file(&buffer, &length)) {
 		goto end;
 	}
 
@@ -328,7 +328,7 @@ void udp_accept_connection(void)
 	log_client(&cli_addr);
 #endif /* DEBUG */
 
-	if (get_quote_of_the_day(&buffer, &length)) {
+	if (get_quote_from_file(&buffer, &length)) {
 		return;
 	}
 

--- a/src/network.c
+++ b/src/network.c
@@ -34,7 +34,7 @@
 #include "daemon.h"
 #include "journal.h"
 #include "network.h"
-#include "quotes.h"
+#include "quotes_file.h"
 
 #define IPPROTO_PART_STRING(opt)	(((opt)->iproto == PROTOCOL_BOTH) ? "4/" : "")
 #define TCP_CONNECTION_BACKLOG		50

--- a/src/network.c
+++ b/src/network.c
@@ -205,8 +205,9 @@ void set_up_ipv6_socket(const struct options *const opt)
 
 void close_socket(void)
 {
-	if (sockfd < 0)
+	if (sockfd < 0) {
 		return;
+	}
 	if (unlikely(close(sockfd))) {
 		const int errsave = errno;
 		assert(errno != 0);
@@ -290,8 +291,9 @@ void tcp_accept_connection(void)
 	log_client(&cli_addr);
 #endif /* DEBUG */
 
-	if (get_quote_of_the_day(&buffer, &length))
+	if (get_quote_of_the_day(&buffer, &length)) {
 		goto end;
+	}
 
 	tcp_write(buffer,
 		  &length,
@@ -326,8 +328,9 @@ void udp_accept_connection(void)
 	log_client(&cli_addr);
 #endif /* DEBUG */
 
-	if (get_quote_of_the_day(&buffer, &length))
+	if (get_quote_of_the_day(&buffer, &length)) {
 		return;
+	}
 
 	udp_write(buffer,
 		 &length,

--- a/src/network.h
+++ b/src/network.h
@@ -2,7 +2,7 @@
  * network.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/pid_file.c
+++ b/src/pid_file.c
@@ -2,7 +2,7 @@
  * pid_file.c
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/pid_file.c
+++ b/src/pid_file.c
@@ -58,17 +58,19 @@ void pidfile_create(const struct options *opt)
 	if (!fh) {
 		journal("Unable to open pid file: %s.\n", strerror(errno));
 
-		if (opt->require_pidfile)
+		if (opt->require_pidfile) {
 			cleanup(EXIT_IO, 1);
-		else
+		} else {
 			return;
+		}
 	}
 	if (fprintf(fh, "%d\n", getpid()) < 0) {
 		JTRACE();
 		perror("Unable to write process id to pid file");
 
-		if (opt->require_pidfile)
+		if (opt->require_pidfile) {
 			cleanup(EXIT_IO, 1);
+		}
 	}
 	wrote_pidfile = 1;
 	fclose(fh);
@@ -76,8 +78,9 @@ void pidfile_create(const struct options *opt)
 
 void pidfile_remove(const struct options *opt)
 {
-	if (!opt->pid_file)
+	if (!opt->pid_file) {
 		return;
+	}
 
 	if (access(opt->pid_file, F_OK)) {
 		journal("Pid file \"%s\" is inaccessible: %s.\n",

--- a/src/pid_file.h
+++ b/src/pid_file.h
@@ -2,7 +2,7 @@
  * pid_file.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/quotes_file.c
+++ b/src/quotes_file.c
@@ -1,5 +1,5 @@
 /*
- * quotes.c
+ * quotes_file.c
  *
  * qotd - A simple QOTD daemon.
  * Copyright (c) 2015-2016 Emmie Smith
@@ -33,7 +33,7 @@
 #include "daemon.h"
 #include "journal.h"
 #include "security.h"
-#include "quotes.h"
+#include "quotes_file.h"
 
 #define QUOTE_SIZE		512  /* Set by RFC 865 */
 

--- a/src/quotes_file.c
+++ b/src/quotes_file.c
@@ -2,7 +2,7 @@
  * quotes_file.c
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/quotes_file.c
+++ b/src/quotes_file.c
@@ -168,15 +168,17 @@ static int format_quote(void)
 		quote_buffer.length = length;
 	}
 
-	if (opt->pad_quotes)
+	if (opt->pad_quotes) {
 		sprintf(quote_buffer.data, "\n%s\n\n", quote_file_data.array[i]);
-	else
+	} else {
 		strncpy(quote_buffer.data, quote_file_data.array[i], length);
+	}
 
-	if (opt->pad_quotes)
+	if (opt->pad_quotes) {
 		journal("Sending quotation:%s<end>\n", quote_buffer.data);
-	else
+	} else {
 		journal("Sending quotation:\n%s<end>\n", quote_buffer.data);
+	}
 
 	quote_buffer.str_length = length;
 	return 0;
@@ -206,8 +208,9 @@ static int readquotes_file(void)
 	size_t i, fsize;
 
 	fsize = get_file_size();
-	if (unlikely(fsize == (size_t)-1))
+	if (unlikely(fsize == (size_t)-1)) {
 		return -1;
+	}
 
 	/* Allocate file buffer */
 	if (fsize > quote_file_data.buf_length) {
@@ -233,8 +236,9 @@ static int readquotes_file(void)
 		char *c;
 
 		c = &quote_file_data.buffer[i];
-		if (!*c)
+		if (!*c) {
 			*c = ' ';
+		}
 	}
 	quote_file_data.buffer[fsize] = '\0';
 	quote_file_data.buf_length = fsize;
@@ -262,8 +266,9 @@ static int readquotes_line(void)
 	size_t fsize, quotes;
 
 	fsize = get_file_size();
-	if (unlikely(fsize == (size_t)-1))
+	if (unlikely(fsize == (size_t)-1)) {
 		return -1;
+	}
 
 	/* Allocate file buffer */
 	if (fsize > quote_file_data.buf_length) {
@@ -339,8 +344,9 @@ static int readquotes_percent(void)
 	quotes = 0;
 	has_percent = 0;
 	fsize = get_file_size();
-	if (unlikely(fsize == (size_t)-1))
+	if (unlikely(fsize == (size_t)-1)) {
 		return -1;
+	}
 
 	/* Allocate file buffer */
 	if (fsize > quote_file_data.buf_length) {
@@ -428,15 +434,17 @@ static int readquotes_percent(void)
 
 int open_quotes_file(const struct options *const local_opt)
 {
-	if (local_opt)
+	if (local_opt) {
 		opt = local_opt;
+	}
 
 	if (quotes_fh) {
 		journal("Internal error: quotes file handle is already open\n");
 		cleanup(EXIT_INTERNAL, 1);
 	}
-	if (opt->strict)
+	if (opt->strict) {
 		security_quotes_file_check(opt->quotes_file);
+	}
 
 	quotes_fh = fopen(opt->quotes_file, "r");
 	if (unlikely(!quotes_fh)) {
@@ -471,8 +479,9 @@ int reopen_quotes_file(void)
 
 void close_quotes_file(void)
 {
-	if (quotes_fh)
+	if (quotes_fh) {
 		fclose(quotes_fh);
+	}
 }
 
 void destroy_quote_buffers(void)
@@ -516,8 +525,9 @@ int get_quote_of_the_day(const char **const buffer, size_t *const length)
 	print_quotes();
 #endif /* DEBUG */
 
-	if (format_quote())
+	if (format_quote()) {
 		return -1;
+	}
 	*buffer = quote_buffer.data;
 	*length = quote_buffer.str_length;
 	return 0;

--- a/src/quotes_file.c
+++ b/src/quotes_file.c
@@ -35,8 +35,6 @@
 #include "security.h"
 #include "quotes_file.h"
 
-#define QUOTE_SIZE		512  /* Set by RFC 865 */
-
 #if defined(__APPLE__)
 # define FSEEK			fseek
 # define FTELL			ftell

--- a/src/quotes_file.c
+++ b/src/quotes_file.c
@@ -491,7 +491,7 @@ void destroy_quote_buffers(void)
 	FINAL_FREE(quote_buffer.data);
 }
 
-int get_quote_of_the_day(const char **const buffer, size_t *const length)
+int get_quote_from_file(const char **const buffer, size_t *const length)
 {
 	int (*readquotes)(void);
 

--- a/src/quotes_file.h
+++ b/src/quotes_file.h
@@ -2,7 +2,7 @@
  * quotes_file.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/quotes_file.h
+++ b/src/quotes_file.h
@@ -1,5 +1,5 @@
 /*
- * quotes.h
+ * quotes_file.h
  *
  * qotd - A simple QOTD daemon.
  * Copyright (c) 2015-2016 Emmie Smith
@@ -18,8 +18,8 @@
  * along with qotd.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _QUOTES_H_
-#define _QUOTES_H_
+#ifndef _QUOTES_FILE_H_
+#define _QUOTES_FILE_H_
 
 #include <stddef.h>
 
@@ -32,4 +32,4 @@ void close_quotes_file(void);
 void destroy_quote_buffers(void);
 int get_quote_of_the_day(const char **buffer, size_t *length);
 
-#endif /* _QUOTES_H_ */
+#endif /* _QUOTES_FILE_H_ */

--- a/src/quotes_file.h
+++ b/src/quotes_file.h
@@ -30,6 +30,6 @@ int reopen_quotes_file(void);
 void close_quotes_file(void);
 
 void destroy_quote_buffers(void);
-int get_quote_of_the_day(const char **buffer, size_t *length);
+int get_quote_from_file(const char **buffer, size_t *length);
 
 #endif /* _QUOTES_FILE_H_ */

--- a/src/security.c
+++ b/src/security.c
@@ -2,7 +2,7 @@
  * security.c
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/security.h
+++ b/src/security.h
@@ -1,7 +1,7 @@
 /*
  * security.h
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/signal_handler.c
+++ b/src/signal_handler.c
@@ -1,5 +1,5 @@
 /*
- * signal_hndl.c
+ * signal_handler.c
  *
  * qotd - A simple QOTD daemon.
  * Copyright (c) 2015-2016 Emmie Smith
@@ -26,7 +26,7 @@
 #include "daemon.h"
 #include "journal.h"
 #include "quotes_file.h"
-#include "signal_hndl.h"
+#include "signal_handler.h"
 
 #define JOURNAL(x)				\
 	do {					\
@@ -61,7 +61,7 @@ static void handle_signal(const int signum)
 	}
 }
 
-void signal_hndl_init(void)
+void signal_handler_init(void)
 {
 	signal(SIGSEGV, handle_signal);
 	signal(SIGTERM, handle_signal);

--- a/src/signal_handler.c
+++ b/src/signal_handler.c
@@ -2,7 +2,7 @@
  * signal_handler.c
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/signal_handler.h
+++ b/src/signal_handler.h
@@ -2,7 +2,7 @@
  * signal_handler.h
  *
  * qotd - A simple QOTD daemon.
- * Copyright (c) 2015-2016 Emmie Smith
+ * Copyright (c) 2015-2024 Emmie Smith
  *
  * qotd is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/signal_handler.h
+++ b/src/signal_handler.h
@@ -1,5 +1,5 @@
 /*
- * signal_hndl.h
+ * signal_handler.h
  *
  * qotd - A simple QOTD daemon.
  * Copyright (c) 2015-2016 Emmie Smith
@@ -18,9 +18,9 @@
  * along with qotd.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _SIGNAL_HNDL_H_
-#define _SIGNAL_HNDL_H_
+#ifndef _SIGNAL_HANDLER_H_
+#define _SIGNAL_HANDLER_H_
 
-void signal_hndl_init(void);
+void signal_handler_init(void);
 
-#endif /* _SIGNAL_HNDL_H_ */
+#endif /* _SIGNAL_HANDLER_H_ */

--- a/src/signal_hndl.c
+++ b/src/signal_hndl.c
@@ -25,7 +25,7 @@
 
 #include "daemon.h"
 #include "journal.h"
-#include "quotes.h"
+#include "quotes_file.h"
 #include "signal_hndl.h"
 
 #define JOURNAL(x)				\


### PR DESCRIPTION
Fixes #14 

This adds support for qotd to read quote data from running an external process rather than reading quote entries in a file. This quote will either be retained for the daily period or fetched anew each time, depending on the setting.